### PR TITLE
Nuke User owned AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The currently supported functionality includes:
 * Deleting all Elastic Load Balancers (Classic and V2) in an AWS account
 * Deleting all EBS Volumes in an AWS account
 * Deleting all unprotected EC2 instances in an AWS account
+* Deleting all AMIs in an AWS account
 
 ### WARNING: THIS TOOL IS HIGHLY DESTRUCTIVE, ALL SUPPORTED RESOURCES WILL BE DELETED. ITS EFFECTS ARE IRREVERSIBLE AND SHOULD NEVER BE USED IN A PRODUCTION ENVIRONMENT
 

--- a/aws/ami.go
+++ b/aws/ami.go
@@ -25,7 +25,15 @@ func getAllAMIs(session *session.Session, region string, excludeAfter time.Time)
 
 	var imageIds []*string
 	for _, image := range output.Images {
-		imageIds = append(imageIds, image.ImageId)
+		layout := "2006-01-02T15:04:05.000Z"
+		createdTime, err := time.Parse(layout, *image.CreationDate)
+		if err != nil {
+			return nil, err
+		}
+
+		if excludeAfter.After(createdTime) {
+			imageIds = append(imageIds, image.ImageId)
+		}
 	}
 
 	return imageIds, nil

--- a/aws/ami.go
+++ b/aws/ami.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+)
+
+// Returns a formatted string of AMI Image ids
+func getAllAMIs(session *session.Session, region string, excludeAfter time.Time) ([]*string, error) {
+	svc := ec2.New(session)
+
+	params := &ec2.DescribeImagesInput{
+		Owners: []*string{awsgo.String("self")},
+	}
+
+	output, err := svc.DescribeImages(params)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	var imageIds []*string
+	for _, image := range output.Images {
+		imageIds = append(imageIds, image.ImageId)
+	}
+
+	return imageIds, nil
+}

--- a/aws/ami_test.go
+++ b/aws/ami_test.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	awsgo "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/aws-nuke/util"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestAMI(t *testing.T, session *session.Session, name string) ec2.Image {
+	svc := ec2.New(session)
+	instance := createTestEC2Instance(t, session, name, false)
+	output, err := svc.CreateImage(&ec2.CreateImageInput{
+		InstanceId: instance.InstanceId,
+		Name:       awsgo.String(name),
+	})
+
+	if err != nil {
+		assert.Failf(t, "Could not create test AMI", errors.WithStackTrace(err).Error())
+	}
+
+	err = svc.WaitUntilImageAvailable(&ec2.DescribeImagesInput{
+		ImageIds: []*string{output.ImageId},
+	})
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	images, err := svc.DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: []*string{output.ImageId},
+	})
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	return *images.Images[0]
+}
+
+func TestListAMIs(t *testing.T) {
+	t.Parallel()
+
+	region := getRandomRegion()
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "aws-nuke-test-" + util.UniqueID()
+	image := createTestAMI(t, session, uniqueTestID)
+	// clean up after this test
+	defer nukeAllAMIs(session, []*string{image.ImageId})
+	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
+
+	amis, err := getAllAMIs(session, region, time.Now().Add(1*time.Hour*-1))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of AMIs")
+	}
+
+	assert.NotContains(t, awsgo.StringValueSlice(amis), *image.ImageId)
+
+	amis, err = getAllAMIs(session, region, time.Now().Add(1*time.Hour))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of AMIs")
+	}
+
+	assert.Contains(t, awsgo.StringValueSlice(amis), *image.ImageId)
+}
+
+func TestNukeAMIs(t *testing.T) {
+	t.Parallel()
+
+	region := getRandomRegion()
+	session, err := session.NewSession(&awsgo.Config{
+		Region: awsgo.String(region)},
+	)
+	svc := ec2.New(session)
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	uniqueTestID := "aws-nuke-test-" + util.UniqueID()
+	image := createTestAMI(t, session, uniqueTestID)
+
+	// clean up ec2 instance created by the above call
+	defer nukeAllEc2Instances(session, findEC2InstancesByNameTag(t, session, uniqueTestID))
+
+	_, err = svc.DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: []*string{image.ImageId},
+	})
+
+	if err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	if err := nukeAllAMIs(session, []*string{image.ImageId}); err != nil {
+		assert.Fail(t, errors.WithStackTrace(err).Error())
+	}
+
+	amis, err := getAllAMIs(session, region, time.Now().Add(1*time.Hour))
+	if err != nil {
+		assert.Fail(t, "Unable to fetch list of AMIs")
+	}
+
+	assert.NotContains(t, awsgo.StringValueSlice(amis), *image.ImageId)
+}

--- a/aws/ami_test.go
+++ b/aws/ami_test.go
@@ -25,6 +25,7 @@ func createTestAMI(t *testing.T, session *session.Session, name string) ec2.Imag
 	}
 
 	err = svc.WaitUntilImageAvailable(&ec2.DescribeImagesInput{
+		Owners:   []*string{awsgo.String("self")},
 		ImageIds: []*string{output.ImageId},
 	})
 

--- a/aws/ami_types.go
+++ b/aws/ami_types.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// AMIs - represents all user owned AMIs
+type AMIs struct {
+	ImageIds []string
+}
+
+// ResourceName - the simple name of the aws resource
+func (image AMIs) ResourceName() string {
+	return "ami"
+}
+
+// ResourceIdentifiers - The AMI image ids
+func (image AMIs) ResourceIdentifiers() []string {
+	return image.ImageIds
+}
+
+// Nuke - nuke 'em all!!!
+func (image AMIs) Nuke(session *session.Session) error {
+	return nil
+}

--- a/aws/ami_types.go
+++ b/aws/ami_types.go
@@ -1,7 +1,9 @@
 package aws
 
 import (
+	awsgo "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 )
 
 // AMIs - represents all user owned AMIs
@@ -21,5 +23,9 @@ func (image AMIs) ResourceIdentifiers() []string {
 
 // Nuke - nuke 'em all!!!
 func (image AMIs) Nuke(session *session.Session) error {
+	if err := nukeAllAMIs(session, awsgo.StringSlice(image.ImageIds)); err != nil {
+		return errors.WithStackTrace(err)
+	}
+
 	return nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -132,6 +132,19 @@ func GetAllResources(regions []string, excludedRegions []string, excludeAfter ti
 		resourcesInRegion.Resources = append(resourcesInRegion.Resources, ebsVolumes)
 		// End EBS Volumes
 
+		// AMIs
+		imageIds, err := getAllAMIs(session, region, excludeAfter)
+		if err != nil {
+			return nil, errors.WithStackTrace(err)
+		}
+
+		amis := AMIs{
+			ImageIds: awsgo.StringValueSlice(imageIds),
+		}
+
+		resourcesInRegion.Resources = append(resourcesInRegion.Resources, amis)
+		// End AMIs
+
 		account.Resources[region] = resourcesInRegion
 	}
 

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -23,7 +23,7 @@ func CreateCli(version string) *cli.App {
 	app.HelpName = app.Name
 	app.Author = "Gruntwork <www.gruntwork.io>"
 	app.Version = version
-	app.Usage = "A CLI tool to cleanup AWS resources (ASG, ELB, ELBv2, EBS, EC2). THIS TOOL WILL COMPLETELY REMOVE ALL RESOURCES AND ITS EFFECTS ARE IRREVERSIBLE!!!"
+	app.Usage = "A CLI tool to cleanup AWS resources (ASG, ELB, ELBv2, EBS, EC2, AMI). THIS TOOL WILL COMPLETELY REMOVE ALL RESOURCES AND ITS EFFECTS ARE IRREVERSIBLE!!!"
 	app.Flags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "exclude-region",


### PR DESCRIPTION
This PR does the following:

- Adds support for listing and nuking Amazon Machine Images owned by the user
- Adds tests for this functionality